### PR TITLE
Modify test runner to allow for no passing cases

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -32,11 +32,13 @@ test('Testing All Conifgurable Rules', function (t) {
     if (testObject[rule] === null) {
       return t.ok(ruleNotSet, rule + ' not configured');
     }
+    var fCases = testObject[rule].fail;
+    var pCases = testObject[rule].pass
 
-    testObject[rule].fail.forEach(function (text) {
+    fCases && fCases.forEach(function (text) {
       t.notOk(passesRule(rule, text), rule + ' fails');
     });
-    testObject[rule].pass.forEach(function (text) {
+    pCases && pCases.forEach(function (text) {
       t.ok(passesRule(rule, text), rule + ' passes');
     });
   });


### PR DESCRIPTION
Right now it is annoying to have to define the pass property of the test object as an empty array when not needed. Check to see if prop existing before iterating over.


Related: #188