### PR TITLE
Add postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "goodparts",
   "description": "An ESLint Style that only allows JavaScript the Good Parts (and \"Better Parts\") in your codebase.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": ".eslintrc.js",
   "scripts": {
     "test": "tape test/index.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "tape test/index.js",
     "coverage": "node_modules/.bin/istanbul cover tape test/index.js",
-    "lint": "bin/cmd.js ."
+    "lint": "bin/cmd.js .",
+    "postinstall": "ln -sf $(pwd)/.eslintrc.js $(pwd)/../../.eslintrc.js"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",


### PR DESCRIPTION
Automatically symlinks the .eslintrc file into the project root after installing goodparts, meaning we can use it with atom (if we enable the global eslint installation)