### PR TITLE
escape pwd for pathname contaning spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "coverage": "node_modules/.bin/istanbul cover tape test/index.js",
     "lint": "bin/cmd.js .",
     "lint:fix": "bin/cmd.js . --fix",
-    "postinstall": "ln -sf $(pwd)/.eslintrc.js $(pwd)/../../.eslintrc.js"
+    "postinstall": "ln -sf \"$(pwd)\"/.eslintrc.js \"$(pwd)\"/../../.eslintrc.js"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/rules/stylistic_issues.js
+++ b/rules/stylistic_issues.js
@@ -118,5 +118,6 @@ module.exports = {
     beforeColon: false, afterColon: true, mode: 'strict'
   }], // https://github.com/dwyl/goodparts/issues/198
   'no-restricted-syntax': 0, // https://github.com/dwyl/goodparts/issues/111
-  'no-continue': 2 // https://github.com/dwyl/goodparts/issues/162
+  'no-continue': 2, // https://github.com/dwyl/goodparts/issues/162,
+  'func-name-matching': 2 // https://github.com/dwyl/goodparts/issues/256
 };

--- a/test/fixtures/stylistic_issues.js
+++ b/test/fixtures/stylistic_issues.js
@@ -295,5 +295,9 @@ module.exports = {
   'key-spacing': {
     fail: ['var obj = {key : 42};'],
     pass: ['var obj = {key: 42};']
+  },
+  'func-name-matching': {
+    fail: ['var bar = function foo () {return 42;};'],
+    pass: ['var bar = function bar () {return 42;};']
   }
 };


### PR DESCRIPTION
- resolve #257 by adding double quotes around $(pwd)
- resolve new rule in #256 func-name-matching