### PR TITLE
Cli exit code

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -3,13 +3,15 @@
 
 var path = require('path');
 var eslint = require('eslint');
+var parse = require('minimist');
 
 var configFilePath = path.resolve(__dirname, '..', '.eslintrc.js');
 var cli, report;
 
-var dir = process.argv.slice(2, 3);
-var flags = process.argv.slice(3);
-var shouldFix = flags.indexOf('--fix') > -1;
+var args = parse(process.argv.slice(2));
+var dir = args._.slice(0, 1);
+
+var shouldFix = args.hasOwnProperty('fix');
 
 cli = new eslint.CLIEngine({ configFile: configFilePath, fix: shouldFix });
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -20,3 +20,10 @@ if (shouldFix) {
 }
 
 console.log(cli.getFormatter()(report.results)); // eslint-disable-line
+
+// End with exit code 1 if there are errors
+// Use process.exit instead of throwing to mimic the behaviour of eslints bin
+// We don't want a stacktrace, it would just be confusing
+if (report.errorCount) {
+    process.exit(1); // eslint-disable-line
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "goodparts",
   "description": "An ESLint Style that only allows JavaScript the Good Parts (and \"Better Parts\") in your codebase.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "main": ".eslintrc.js",
   "scripts": {
     "test": "tape test/index.js test/**/*.test.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "eslint": "^3.9.1"
+    "eslint": "^3.9.1",
+    "minimist": "^1.2.0"
   },
   "bin": "./bin/cmd.js",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.3",
   "main": ".eslintrc.js",
   "scripts": {
-    "test": "tape test/index.js",
+    "test": "tape test/index.js test/**/*.test.js",
     "coverage": "node_modules/.bin/istanbul cover tape test/index.js",
     "lint": "bin/cmd.js .",
     "lint:fix": "bin/cmd.js . --fix",

--- a/test/bin/cmd.test.js
+++ b/test/bin/cmd.test.js
@@ -1,19 +1,26 @@
 'use strict';
 
 var test = require('tape');
-var cli = require('../../bin/cmd.js');
+var utils = require('./utils.js');
 var exec = require('child_process').exec;
 
 test('cli executes without error', function (t) {
-  cli(['./rules']);
-  t.end();
+  exec('./bin/cmd.js .', function (err, stdout, stderr) {
+    t.notOk(err, 'Expect no errors thrown');
+    t.notOk(stderr, 'Expect nothing logged to stderr');
+    t.end();
+  });
 });
 
 test('cli exits with code 1 when there are errors', function (t) {
-  exec('./bin/cmd.js .', function (err, stdout, stderr) {
-    t.ok(err, 'Expect process to exit with code 1');
-    t.ok(stdout, 'Expect errors to be logged to stdout');
+  utils.createFile();
+
+  exec('./bin/cmd.js ./test/bin', function (err, stdout, stderr) {
+    t.equal(err.code, 1, 'Expect process to exit with code 1');
+    t.ok(stdout.replace('\n', ''), 'Expect errors to be logged to stdout');
     t.notOk(stderr, 'Don\'t expect anything to be logged to stderr');
+
+    utils.deleteFile();
     t.end();
   });
 });

--- a/test/bin/cmd.test.js
+++ b/test/bin/cmd.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var test = require('tape');
+var cli = require('../../bin/cmd.js');
+var exec = require('child_process').exec;
+
+test('cli executes without error', function (t) {
+  cli(['./rules']);
+  t.end();
+});
+
+test('cli exits with code 1 when there are errors', function (t) {
+  exec('./bin/cmd.js .', function (err, stdout, stderr) {
+    t.ok(err, 'Expect process to exit with code 1');
+    t.ok(stdout, 'Expect errors to be logged to stdout');
+    t.notOk(stderr, 'Don\'t expect anything to be logged to stderr');
+    t.end();
+  });
+});

--- a/test/bin/utils.js
+++ b/test/bin/utils.js
@@ -1,0 +1,28 @@
+/*
+ * Utility functions to help with CLI testing
+ */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+/*
+ * Creates a dummy file with known linter errors to help
+ * simulate the CLI catching errors.
+ * Just copies over one of the test fixtures.
+ */
+exports.createFile = function createFile () {
+  var contents = fs.readFileSync(
+    path.resolve(__dirname, '..', 'fixtures', 'ident.fail.js'),
+    'utf8'
+  );
+
+  fs.writeFileSync(path.join(__dirname, 'dummy.js'), contents);
+};
+
+/*
+ * Deletes the dummy file
+ */
+exports.deleteFile = function deleteFile () {
+  fs.unlinkSync(path.join(__dirname, 'dummy.js'));
+};

--- a/test/index.js
+++ b/test/index.js
@@ -59,10 +59,3 @@ test('Testing All Conifgurable Rules', function (t) {
 
   t.end();
 });
-
-test('Testing bin file executes without error', function (t) {
-  /*eslint-disable */
-  require('../bin/cmd.js');
-  /*eslint-ensable */
-  t.end();
-});


### PR DESCRIPTION
Fixes #266 

### Major Changes
* CLI exits with code 1 if there are linter errors
* Separate out the CLI tests from the other tests

### Minor Changes
* Use minimist to parse CLI args