### PR TITLE
Remove symlinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Then you can add the following script to your `package.json`:
   "lint": "node_modules/.bin/goodparts path/to/files/for/linting"
 }
 ```
+The `goodparts` command line tool supports `eslint`'s autofix flag `--fix`. Not all errors can be autofixed, but a great deal can, simply with:
+```
+$ node_modules/.bin/goodparts /path/to/dir --fix
+```
+While we're working on an [atom plugin](https://github.com/dwyl/goodparts/issues/243), you can still use `goodparts` to lint your code in your editor using the `linter-eslint` plugin for atom. To do this, you need a `.eslintrc.js` file in your project that reflects the `goodparts` configuration. Luckily we have a command line option for this too! Simply run:
+```
+$ node_modules/.bin/goodparts /path/to/dir --link
+```
+This will create a symlink to the goodparts configuration file at `/path/to/dir/.eslintrc.js`, which we reccommend you git-ignore for now.
 
 <br />
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+var exec = require('child_process').exec;
 var path = require('path');
 var eslint = require('eslint');
 var parse = require('minimist');
@@ -11,21 +12,50 @@ var cli, report;
 var args = parse(process.argv.slice(2));
 var dir = args._.slice(0, 1);
 
-var shouldFix = args.hasOwnProperty('fix');
+/*
+ * Symlinks the eslintrc file into the dependent project's root
+ */
+function createSymLink () {
+  var fullpath = path.resolve(dir[0]);
 
-cli = new eslint.CLIEngine({ configFile: configFilePath, fix: shouldFix });
+  exec(
+    'ln -sf ' + configFilePath + ' ' + path.join(fullpath, '.eslintrc.js'),
+    function (err) {
+      if (err) {
+        console.error('Error encountered when trying to create symlink', err); // eslint-disable-line
+      }
 
-report = cli.executeOnFiles(dir);
-
-if (shouldFix) {
-  eslint.CLIEngine.outputFixes(report);
+      console.log('Successfully symlinked .eslintrc.js to ' + fullpath); // eslint-disable-line
+    }
+  );
 }
 
-console.log(cli.getFormatter()(report.results)); // eslint-disable-line
+/*
+ * Lints the directory passed in as a command line argument
+ */
+function lintDirectory () {
+  var shouldFix = args.hasOwnProperty('fix');
 
-// End with exit code 1 if there are errors
-// Use process.exit instead of throwing to mimic the behaviour of eslints bin
-// We don't want a stacktrace, it would just be confusing
-if (report.errorCount) {
-    process.exit(1); // eslint-disable-line
+  cli = new eslint.CLIEngine({ configFile: configFilePath, fix: shouldFix });
+
+  report = cli.executeOnFiles(dir);
+
+  if (shouldFix) {
+    eslint.CLIEngine.outputFixes(report);
+  }
+
+  console.log(cli.getFormatter()(report.results)); // eslint-disable-line
+
+  // End with exit code 1 if there are errors
+  // Use process.exit instead of throwing to mimic the behaviour of eslints bin
+  // We don't want a stacktrace, it would just be confusing
+  if (report.errorCount) {
+      process.exit(1); // eslint-disable-line
+  }
+}
+
+if (args.hasOwnProperty('link')) {
+  createSymLink();
+} else {
+  lintDirectory();
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "tape test/index.js test/**/*.test.js",
     "coverage": "node_modules/.bin/istanbul cover tape test/index.js",
     "lint": "bin/cmd.js .",
-    "lint:fix": "bin/cmd.js . --fix",
-    "postinstall": "ln -sf \"$(pwd)\"/.eslintrc.js \"$(pwd)\"/../../.eslintrc.js"
+    "lint:fix": "bin/cmd.js . --fix"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".eslintrc.js",
   "scripts": {
     "test": "tape test/index.js test/**/*.test.js",
-    "coverage": "node_modules/.bin/istanbul cover tape test/index.js",
+    "coverage": "istanbul cover tape test/index.js test/**/*.test.js",
     "lint": "bin/cmd.js .",
     "lint:fix": "bin/cmd.js . --fix"
   },

--- a/test/bin/cmd.test.js
+++ b/test/bin/cmd.test.js
@@ -2,6 +2,7 @@
 
 var test = require('tape');
 var utils = require('./utils.js');
+var path = require('path');
 var exec = require('child_process').exec;
 
 test('cli executes without error', function (t) {
@@ -13,14 +14,17 @@ test('cli executes without error', function (t) {
 });
 
 test('cli exits with code 1 when there are errors', function (t) {
-  utils.createFile();
+  var source = path.resolve(__dirname, '..', 'fixtures', 'ident.fail.js');
+  var target = path.join(__dirname, 'dummy.js');
+
+  utils.copyFile(source, target);
 
   exec('./bin/cmd.js ./test/bin', function (err, stdout, stderr) {
     t.equal(err.code, 1, 'Expect process to exit with code 1');
     t.ok(stdout.replace('\n', ''), 'Expect errors to be logged to stdout');
     t.notOk(stderr, 'Don\'t expect anything to be logged to stderr');
 
-    utils.deleteFile();
+    utils.deleteFile(target);
     t.end();
   });
 });

--- a/test/bin/cmd.test.js
+++ b/test/bin/cmd.test.js
@@ -28,3 +28,17 @@ test('cli exits with code 1 when there are errors', function (t) {
     t.end();
   });
 });
+
+test('cli creates a symlink file when called with "--link"', function (t) {
+  exec('./bin/cmd.js ./test/bin --link', function (err, stdout, stderr) {
+    t.notOk(err, 'Expect no errors thrown');
+    t.notOk(stderr, 'Expect nothing logged to stderr');
+    t.ok(
+      /Successfully symlinked .eslintrc.js to /.test(stdout),
+      'Expect success message in stdout'
+    );
+
+    utils.deleteFile(path.join(__dirname, '.eslintrc.js'));
+    t.end();
+  });
+});

--- a/test/bin/utils.js
+++ b/test/bin/utils.js
@@ -4,25 +4,19 @@
 'use strict';
 
 var fs = require('fs');
-var path = require('path');
 
 /*
  * Creates a dummy file with known linter errors to help
  * simulate the CLI catching errors.
  * Just copies over one of the test fixtures.
  */
-exports.createFile = function createFile () {
-  var contents = fs.readFileSync(
-    path.resolve(__dirname, '..', 'fixtures', 'ident.fail.js'),
-    'utf8'
-  );
-
-  fs.writeFileSync(path.join(__dirname, 'dummy.js'), contents);
+exports.copyFile = function copyFile (source, target) {
+  fs.writeFileSync(target, fs.readFileSync(source, 'utf8'));
 };
 
 /*
  * Deletes the dummy file
  */
-exports.deleteFile = function deleteFile () {
-  fs.unlinkSync(path.join(__dirname, 'dummy.js'));
+exports.deleteFile = function deleteFile (target) {
+  fs.unlinkSync(target);
 };


### PR DESCRIPTION
Related to #248 

So thanks to #267 I finally got round to writing enough tests for this to be worth PR-ing.

### Major Changes
* Post-install script removed; default behaviour on install no is no longer to create a symlinked `.eslintrc.js` file
* CLI flag `--link` added to still allow symlink to be generated if user wishes
* Tests added for `--link` and `--fix` flags

### Minor Changes
* README updated to explain `--link` and `--fix` usage

Not a particularly urgent PR. Also I'm thinking this PR should bump us up to `1.2.0` rather than `1.1.5` since its a change in behaviour, but open to suggestions.