### PR TITLE
Replace deprecated istanbul with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "homepage": "https://github.com/dwyl/goodparts#readme",
   "scripts": {
     "test": "tape test/index.js test/**/*.test.js",
-    "coverage": "istanbul cover tape test/index.js test/**/*.test.js",
+    "coverage": "nyc report npm test",
     "lint": "bin/cmd.js .",
     "lint:fix": "bin/cmd.js . --fix"
   },
   "devDependencies": {
-    "istanbul": "^0.4.5",
+    "nyc": "^13.3.0",
     "tape": "^4.6.0"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #286 

- add `nyc` to manifest
- remove `Istanbul` from the manifest
- update coverage script with `nyc`
- add `nyc_output` to gitignore